### PR TITLE
Fix: Missing staticmethod decorator for time.sleep

### DIFF
--- a/daemons/message/__init__.py
+++ b/daemons/message/__init__.py
@@ -23,7 +23,7 @@ class MessageDaemon(Daemon):
 
     # This alias for sleep is placed here to allow extensions to change the
     # idle behaviour of the loop without monkey patching the time library.
-    sleep = time.sleep
+    sleep = staticmethod(time.sleep)
 
     def __init__(self, pidfile, idle_time=0.1):
 


### PR DESCRIPTION
Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
