### PR TITLE
Fix: Gevent pool spawning

### DIFF
--- a/daemons/message/geventd.py
+++ b/daemons/message/geventd.py
@@ -35,4 +35,4 @@ class GeventMessageDaemon(PooledMessageDaemon):
             self.pool.size - self.pool.free_count(),
             self.pool.free_count(),
         )
-        self.pool.spawn_raw(func)
+        self.pool.spawn(func)


### PR DESCRIPTION
The latest version of gevent has removed the spawn_raw method
from the green pool object. Instead, the normal spawn is used
now which should be backwards compatible.

The spawn_raw was originally used as an optimization based on the
docs provided by gevent.

Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
