### PR TITLE
Remove multi-line license entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,16 @@ from setuptools import setup, find_packages
 with open("README.rst") as f:
     readme = f.read()
 
-with open("LICENSE") as f:
-    license = f.read()
-
 setup(
     name="daemons",
     version="1.3.1",
     url="https://github.com/kevinconway/daemons",
-    license=license,
+    license="'Apache License 2.0",
     description="Well behaved unix daemons for every occasion.",
     author="Kevin Conway",
     author_email="kevinjacobconway@gmail.com",
     long_description=readme,
     classifiers=[],
     packages=find_packages(exclude=["tests", "build", "dist", "docs"]),
-    requires=[],
+    install_requires=[],
 )


### PR DESCRIPTION
This field must be a single line to produce a valid PKG-INFO file.