### PR TITLE
Fix error handling in `stop()` method on Python 3.10

### DIFF
--- a/daemons/startstop/simple.py
+++ b/daemons/startstop/simple.py
@@ -16,6 +16,11 @@ from ..interfaces import startstop
 
 LOG = logging.getLogger(__name__)
 
+SUCCESS_MSG = "an integer is required"
+
+if sys.version_info >= (3, 10, 0):
+    SUCCESS_MSG = "object cannot be interpreted as an integer"
+
 
 class SimpleStartStopManager(startstop.StartStopManager):
 
@@ -78,7 +83,7 @@ class SimpleStartStopManager(startstop.StartStopManager):
 
         except TypeError as err:
 
-            if "an integer is required" in str(err):
+            if SUCCESS_MSG in str(err):
 
                 LOG.info("Succesfully stopped the process.")
                 return None


### PR DESCRIPTION
On Python 3.10, when you issue the `RunDaemon.stop()` method, it throws an error and quits with a failure return code:
```python3
Failed to stop the process:
Traceback (most recent call last):
  File "/home/alex/.pyenv/versions/3.10-dev/lib/python3.10/site-packages/daemons/startstop/simple.py", line 66, in stop
    self.send(signal.SIGTERM)
  File "/home/alex/.pyenv/versions/3.10-dev/lib/python3.10/site-packages/daemons/signal/simple.py", line 79, in send
    os.kill(self.pid, signum)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

On older Python versions, `os.kill(None, signal)` throws a `TypeError` with one message, and Python 3.10 changed that message.

On Python 3.10b1:
```python3
import os

try:
  os.kill(None, 0)
except TypeError as e:
  print(e)

'NoneType' object cannot be interpreted as an integer
```

On Python 3.9 and below:
```python3
import os

try:
  os.kill(None, 0)
except TypeError as e:
  print(e)

an integer is required (got type NoneType)
```

The `stop()` method catches a `TypeError` and checks to make sure the error message contains `"an integer is required"`, and because that message changes in 3.10, `daemons` raises an error.

This PR looks at the Python version and checks for the correct error message on Python versions at and below 3.9, and 3.10 and above.