### PR TITLE
Bump for py3.10 fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst") as f:
 
 setup(
     name="daemons",
-    version="1.3.1",
+    version="1.3.2",
     url="https://github.com/kevinconway/daemons",
     license="'Apache License 2.0",
     description="Well behaved unix daemons for every occasion.",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,py36,py37,pep8,pyflakes
+envlist = py26,py27,py32,py33,py34,py35,py36,py37,py38,py39,py310,pep8,pyflakes
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
This bumps the version to release a fix for Python3.10 related to the
changes in error raised by os.kill.